### PR TITLE
Adicionando tratamento para caminhos de arquivos no windows

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,8 +6,8 @@ from webscraping.processors.report_creator import create_report
 
 
 def main():
-    resources_path = "%s%s" % (os.getcwd(), "/webscraping/resources/")
-    repositories_path = "%s%s" % (resources_path, "repositories.txt")
+    resources_path = os.path.join(os.getcwd(), "webscraping", "resources")
+    repositories_path = os.path.join(resources_path, "repositories.txt")
     repositories = get_repositories_list(repositories_path)
 
     for repo in repositories:
@@ -16,7 +16,7 @@ def main():
         repo_metrics = analyze_repo(root)
         report = create_report(repo, root, repo_metrics)
         report_file_name = "{}".format(repo.replace("/", "_"))
-        export_path = "{}{}.txt".format(resources_path, report_file_name)
+        export_path = "{}.txt".format(os.path.join(resources_path, report_file_name))
         write_file(export_path, report)
 
 

--- a/webscraping/processors/files.py
+++ b/webscraping/processors/files.py
@@ -29,7 +29,7 @@ def write_file(file_path, content):
     :param content: Conteúdo do arquivo a ser escrito.
     """
     try:
-        with open(file_path, "a+") as file:
+        with open(file_path, "a+", encoding="utf-8") as file:
             file.write(content)
         print("Arquivo gerado com sucesso em {}".format(file_path))
     except Exception as e:


### PR DESCRIPTION
No windows o padrão de caminhos é diferente, assim o recomendado é utilizar o os.path.join para evitar essas diferenças entre os.